### PR TITLE
Add face for col-highlight (used by col-highlight and crosshair)

### DIFF
--- a/base16-chalk-theme.el
+++ b/base16-chalk-theme.el
@@ -21,7 +21,7 @@
       (blue "#6fc2ef")
       (purple "#e1a3ee"))
 
-  (custom-theme-set-faces 
+  (custom-theme-set-faces
    'base16-chalk
 
    ;; Built-in stuff (Emacs 23)
@@ -44,6 +44,9 @@
 
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
+
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
 
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))

--- a/base16-default-theme.el
+++ b/base16-default-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-eighties-theme.el
+++ b/base16-eighties-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-greenscreen-theme.el
+++ b/base16-greenscreen-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-mocha-theme.el
+++ b/base16-mocha-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-monokai-theme.el
+++ b/base16-monokai-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-ocean-theme.el
+++ b/base16-ocean-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-railscasts-theme.el
+++ b/base16-railscasts-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-solarized-theme.el
+++ b/base16-solarized-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 

--- a/base16-tomorrow-theme.el
+++ b/base16-tomorrow-theme.el
@@ -45,6 +45,9 @@
    ;; hl-line-mode
    `(hl-line ((t (:background ,current-line))))
 
+   ;; col-highlight-mode
+   `(col-highlight ((t (:background ,current-line))))
+
    ;; linum-mode
    `(linum ((t (:background ,current-line :foreground ,foreground))))
 


### PR DESCRIPTION
[Col-Highlight](http://www.emacswiki.org/emacs/col-highlight.el) and [Crosshairs](http://www.emacswiki.org/emacs/col-highlight.el) makes use of col-highlight face to highlight the current column.

It would be nice if this was the exact same as `hl-line` and is provided by the theme itself.
