### PR TITLE
Avoid conflict with the "screenshot" package

### DIFF
--- a/screenshots/screenshot.el
+++ b/screenshots/screenshot.el
@@ -55,5 +55,4 @@
 
 (kill-emacs)
 
-(provide 'screenshot)
 ;;; screenshot.el ends here


### PR DESCRIPTION
Because base16-theme's "screenshot.el" is isn't a library intended to
be loaded using `(require 'screenshot)`, it also should not provide a
feature.

There exists an actual package "screenshot", consisting of a library
that provides the feature `screenshot`.  To reduce the risk of
conflicting with that, also add the file "screenshots/.nosearch",
which makes it much less likely that "screenshot.el" ends up on the
`load-path`.