### PR TITLE
Overrides for shm

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -441,6 +441,18 @@ in the terminal.")
      (ido-indicator                                :foreground base08 :background base01)
      (ido-virtual                                  :foreground base04)
 
+;;;; idris-mode
+     (idris-semantic-bound-face                    :inherit font-lock-variable-name-face)
+     (idris-semantic-data-face                     :inherit font-lock-string-face)
+     (idris-semantic-function-face                 :inherit font-lock-function-name-face)
+     (idris-semantic-namespace-face                nil)
+     (idris-semantic-postulate-face                :inherit font-lock-builtin-face)
+     (idris-semantic-type-face                     :inherit font-lock-type-face)
+     (idris-active-term-face                       :inherit highlight)
+     (idris-colon-face                             :inherit font-lock-keyword-face)
+     (idris-equals-face                            :inherit font-lock-keyword-face)
+     (idris-operator-face                          :inherit font-lock-keyword-face)
+
 ;;;; ivy-mode
      (ivy-current-match                            :foreground base09 :background base01)
      (ivy-minibuffer-match-face-1                  :foreground base0E)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -512,7 +512,7 @@ in the terminal.")
      (mm/master-face                               :foreground nil :background nil :inherit region)
      (mm/mirror-face                               :foreground nil :background nil :inherit region)
 
-     ;; markdown-mode
+;;;; markdown-mode
      (markdown-url-face                            :inherit link)
      (markdown-link-face                           :foreground base0D :underline t)
 

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -512,7 +512,7 @@ in the terminal.")
      (mm/master-face                               :foreground nil :background nil :inherit region)
      (mm/mirror-face                               :foreground nil :background nil :inherit region)
 
-;; markdown-mode
+     ;; markdown-mode
      (markdown-url-face                            :inherit link)
      (markdown-link-face                           :foreground base0D :underline t)
 
@@ -619,6 +619,10 @@ in the terminal.")
 ;;;; sh-mode
      (sh-heredoc                                   :foreground nil :weight normal :inherit font-lock-string-face)
      (sh-quoted-exec                               :foreground nil :inherit font-lock-preprocessor-face)
+
+;;;; shm
+     (shm-current-face                             :background base02)
+     (shm-quarantine-face                          :background base09)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -622,7 +622,7 @@ in the terminal.")
 
 ;;;; shm
      (shm-current-face                             :background base02)
-     (shm-quarantine-face                          :background base09)
+     (shm-quarantine-face                          :background base04)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)


### PR DESCRIPTION
- Added support for shm (structured-haskell-mode) to use base16 styling schema
- Fixed comment prefix in one section