### PR TITLE
Shm overrides (Fix for some dark themes)

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -441,6 +441,18 @@ in the terminal.")
      (ido-indicator                                :foreground base08 :background base01)
      (ido-virtual                                  :foreground base04)
 
+;;;; idris-mode
+     (idris-semantic-bound-face                    :inherit font-lock-variable-name-face)
+     (idris-semantic-data-face                     :inherit font-lock-string-face)
+     (idris-semantic-function-face                 :inherit font-lock-function-name-face)
+     (idris-semantic-namespace-face                nil)
+     (idris-semantic-postulate-face                :inherit font-lock-builtin-face)
+     (idris-semantic-type-face                     :inherit font-lock-type-face)
+     (idris-active-term-face                       :inherit highlight)
+     (idris-colon-face                             :inherit font-lock-keyword-face)
+     (idris-equals-face                            :inherit font-lock-keyword-face)
+     (idris-operator-face                          :inherit font-lock-keyword-face)
+
 ;;;; ivy-mode
      (ivy-current-match                            :foreground base09 :background base01)
      (ivy-minibuffer-match-face-1                  :foreground base0E)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -620,10 +620,6 @@ in the terminal.")
      (sh-heredoc                                   :foreground nil :weight normal :inherit font-lock-string-face)
      (sh-quoted-exec                               :foreground nil :inherit font-lock-preprocessor-face)
 
-;;;; shm
-     (shm-current-face                             :inherit region)
-     (shm-quarantine-face                          :inherit highlight)
-
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)
      (show-paren-mismatch                          :foreground base01 :background base09)
@@ -642,6 +638,10 @@ in the terminal.")
      (spaceline-evil-normal                        :foreground base01 :background base0B)
      (spaceline-evil-replace                       :foreground base01 :background base08)
      (spaceline-evil-visual                        :foreground base01 :background base09)
+
+;;;; structured-haskell-mode
+     (shm-current-face                             :background base02)
+     (shm-quarantine-face                          :background base01)
 
 ;;;; term and ansi-term
      (term                                         :foreground base05 :background base00)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -512,7 +512,7 @@ in the terminal.")
      (mm/master-face                               :foreground nil :background nil :inherit region)
      (mm/mirror-face                               :foreground nil :background nil :inherit region)
 
-     ;; markdown-mode
+;;;; markdown-mode
      (markdown-url-face                            :inherit link)
      (markdown-link-face                           :foreground base0D :underline t)
 

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -640,8 +640,8 @@ in the terminal.")
      (spaceline-evil-visual                        :foreground base01 :background base09)
 
 ;;;; structured-haskell-mode
-     (shm-current-face                             :background base02)
-     (shm-quarantine-face                          :background base01)
+     (shm-current-face                             :inherit region)
+     (shm-quarantine-face                          :underline (:style wave :color base08))
 
 ;;;; term and ansi-term
      (term                                         :foreground base05 :background base00)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -512,7 +512,7 @@ in the terminal.")
      (mm/master-face                               :foreground nil :background nil :inherit region)
      (mm/mirror-face                               :foreground nil :background nil :inherit region)
 
-;; markdown-mode
+     ;; markdown-mode
      (markdown-url-face                            :inherit link)
      (markdown-link-face                           :foreground base0D :underline t)
 
@@ -619,6 +619,10 @@ in the terminal.")
 ;;;; sh-mode
      (sh-heredoc                                   :foreground nil :weight normal :inherit font-lock-string-face)
      (sh-quoted-exec                               :foreground nil :inherit font-lock-preprocessor-face)
+
+;;;; shm
+     (shm-current-face                             :background base02)
+     (shm-quarantine-face                          :background base09)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -622,7 +622,7 @@ in the terminal.")
 
 ;;;; shm
      (shm-current-face                             :background base02)
-     (shm-quarantine-face                          :background base09)
+     (shm-quarantine-face                          :background base04)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -621,8 +621,8 @@ in the terminal.")
      (sh-quoted-exec                               :foreground nil :inherit font-lock-preprocessor-face)
 
 ;;;; shm
-     (shm-current-face                             :background base02)
-     (shm-quarantine-face                          :background base04)
+     (shm-current-face                             :inherit region)
+     (shm-quarantine-face                          :inherit highlight)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)


### PR DESCRIPTION
Well, I decided to double check some of the themes after the merge #46.
And turns out quarantine-face does not play nice with some of the dark ones.

What would be great is to have a warning/error color with some opacity reduced.
But sadly we don't have such, so I propose to re-use highlight color.

Also use ':inherit' instead of a concrete color.

A dark theme `quarantine-fac` before:
<img width="257" alt="screen shot 2017-05-04 at 6 38 45 am" src="https://cloud.githubusercontent.com/assets/5430434/25700295/203565e6-3095-11e7-8b0e-9ba9d4ecd0a9.png">

A dark theme `quarantine-face` after:
<img width="235" alt="screen shot 2017-05-04 at 6 39 21 am" src="https://cloud.githubusercontent.com/assets/5430434/25700318/3e387cea-3095-11e7-9ecf-02e23f65d933.png">

A light theme `quarantine-face` after (before attached in the previous PR #46):
<img width="269" alt="screen shot 2017-05-04 at 6 37 57 am" src="https://cloud.githubusercontent.com/assets/5430434/25700329/4f59b188-3095-11e7-98a7-ae4bf1e6bb8b.png">

What do you think?