### PR TITLE
Add faces for cperl-mode that are not already covered

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -214,6 +214,11 @@ in the terminal.")
      (company-tooltip-selection                    :background base02 :inherit font-lock-function-name-face)
      (company-preview-common                       :inherit secondary-selection)
 
+;;;; cperl-mode
+     (cperl-array-face                             :weight bold :inherit font-lock-variable-name-face)
+     (cperl-hash-face                              :weight bold :slant italic :inherit font-lock-variable-name-face)
+     (cperl-nonoverridable-face                    :inherit font-lock-builtin-face)
+
 ;;;; cscope-minor-mode
      (cscope-file-face                             :foreground base0B)
      (cscope-function-face                         :foreground base0D)


### PR DESCRIPTION
cperl-mode highlights arrays and hash variables in a different way. This commit makes them have the same color as any other variable, but still maintains some of the cperl-mode style by keeping both bold and hashes italic as well.

This middle ground looks much better to me, but I'm open to discussion.

Before | After:
![perl](https://cloud.githubusercontent.com/assets/1592315/26527995/6848f104-43a0-11e7-865a-80e3e370bf61.png)

