### PR TITLE
Add option for mode line highlighting to use contrasting colors.

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,6 +59,11 @@ themes. Note that they need to be set before load-theme is called.
 different from the normal background color. Also affects `linum-mode'
 background. Defaults to true.
 
+=base16-highlight-mode-line= - Make the active mode line stand out
+more. There are two choices for applying the emphasis: "box" draws a
+thin border around the active mode line; and "contrast" uses the
+default face's foreground which should result in more contrast.
+Defaults to off (no special emphasis)."
 ** Previews
 
 Theme previews can be found [[https://belak.github.io/base16-emacs/][here]].

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -35,9 +35,16 @@ Also affects `linum-mode' background."
   :group 'base16)
 
 (defcustom base16-highlight-mode-line nil
-  "Make the active mode line stand out more by drawing a thin
-border around it."
-  :type 'boolean
+  "Make the active mode line stand out more.
+
+There are two choices for applying the emphasis:
+  box:      Draws a thin border around the active 
+            mode line.
+  contrast: Use the \"default\" face's foreground
+            which should result in more contrast."
+  :type '(choice (const :tag "Off" nil)
+                 (const :tag "Draw box around" box)
+                 (const :tag "Contrast" contrast))
   :group 'base16)
 
 (defvar base16-shell-colors
@@ -103,9 +110,14 @@ return the actual color value. Otherwise return the value unchanged."
 		  (plist-get colors :base00)))
 
 	   ((string= (symbol-name key) "base16-settings-mode-line-box")
-		(if base16-highlight-mode-line
+		(if (eq base16-highlight-mode-line 'box)
 			(list :line-width 1 :color (plist-get colors :base04))
 		  nil))
+
+	   ((string= (symbol-name key) "base16-settings-mode-line-fg")
+		(if (eq base16-highlight-mode-line 'contrast)
+			(plist-get colors :base05)
+		  (plist-get colors :base04)))
 
 	   (t
 		(let ((maybe-color (plist-get colors (intern (concat ":" (symbol-name key))))))
@@ -232,7 +244,7 @@ return the actual color value. Otherwise return the value unchanged."
      (line-number-current-line                     :inverse-video t)
 
 ;;;; mode-line
-     (mode-line                                    :foreground base04 :background base02 :box base16-settings-mode-line-box)
+     (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)
      (mode-line-buffer-id                          :foreground base0B :background nil)
      (mode-line-emphasis                           :foreground base06 :slant italic)
      (mode-line-highlight                          :foreground base0E :box nil :weight bold)


### PR DESCRIPTION
This change adds an option to the mode line highlighting to use contrasting colors to indicate the active mode line rather than using a box. The readme has also been updated to include the new options.

This is in relation to a comment by the maintainer that not everyone is a fan of the "box" highlighting used by the original change :-)