### PR TITLE
set the vertical border foreground color to base02

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -195,6 +195,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (region                                       :background base02)
      (secondary-selection                          :background base03)
      (trailing-whitespace                          :foreground base0A :background base0C)
+     (vertical-border                              :foreground base02)
      (widget-button                                :underline t)
      (widget-field                                 :background base03 :box (:line-width 1 :color base06))
 


### PR DESCRIPTION
The vertical border color was previously unset in the emacs base16 theme template. This made the border between two vertically split emacs windows jarring because it was still the emacs default white color, and it didn't match any of the other theme colors.

This patch sets the vertical border foreground color to `base02`. If leaving out the vertical border color was intended, then please feel free to close this pull request without merging.

Thank you for maintaining the emacs port of my favorite theme. 