### PR TITLE
Add fic-mode faces

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -375,6 +375,10 @@ return the actual color value.  Otherwise return the value unchanged."
 ;;;; evil-mode
      (evil-search-highlight-persist-highlight-face :background base01 :inverse-video t :inherit font-lock-warning-face)
 
+;;;; fic-mode
+     (fic-author-face                              :foreground base09 :underline t)
+     (fic-face                                     :foreground base08 :weight bold)
+
 ;;;; flycheck-mode
      (flycheck-error                               :underline (:style wave :color base08))
      (flycheck-info                                :underline (:style wave :color base0B))


### PR DESCRIPTION
Hi,

This pull request adds two faces needed to support [fic-mode](https://melpa.org/#/fic-mode).

I did not like the white background of the original faces, so I left it at default. I tried with `:background base01`, but I thought it worked better without it. I kept the `:weight bold` and the `:underline t` from the original faces, but I am happy to remove it if you think this is too much. 

Before:
<img width="770" alt="screen shot 2018-11-16 at 12 22 29 pm" src="https://user-images.githubusercontent.com/471977/48618908-06516380-e99b-11e8-8b53-0cf28f5e0178.png">

After:
<img width="777" alt="screen shot 2018-11-16 at 12 18 11 pm" src="https://user-images.githubusercontent.com/471977/48618921-10736200-e99b-11e8-99f2-cea848791f4c.png">