### PR TITLE
Add missing TeX-error-description faces

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -273,6 +273,10 @@ return the actual color value.  Otherwise return the value unchanged."
      (font-latex-verbatim-face                     :foreground base09)
      (font-latex-warning-face                      :foreground base08)
 
+     (TeX-error-description-error                  :inherit error)
+     (TeX-error-description-tex-said               :inherit font-lock-function-name-face)
+     (TeX-error-description-warning                :inherit warning)
+
 ;;;; clojure-mode
      (clojure-keyword-face                         :foreground base0E)
 


### PR DESCRIPTION
Hi Kaleb,

This PR adds a few missing AUCTeX faces used in error descriptions.

Before:
<img width="687" alt="screen shot 2019-02-13 at 11 36 39 am" src="https://user-images.githubusercontent.com/471977/52706053-bdeb1700-2f84-11e9-9f3b-dfb5aacbaa99.png">

After:
<img width="687" alt="screen shot 2019-02-13 at 11 34 20 am" src="https://user-images.githubusercontent.com/471977/52706079-cd6a6000-2f84-11e9-8ddf-0e4e969ac63e.png">
