### PR TITLE
Add avy support

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -282,6 +282,14 @@ return the actual color value.  Otherwise return the value unchanged."
      (TeX-error-description-tex-said               :inherit font-lock-function-name-face)
      (TeX-error-description-warning                :inherit warning)
 
+;;;; avy
+     (avy-lead-face-0                              :foreground base00 :background base0C)
+     (avy-lead-face-1                              :foreground base00 :background base05)
+     (avy-lead-face-2                              :foreground base00 :background base0E)
+     (avy-lead-face                                :foreground base00 :background base09)
+     (avy-background-face                          :foreground base01)
+     (avy-goto-char-timer-face                     :inherit highlight)
+
 ;;;; clojure-mode
      (clojure-keyword-face                         :foreground base0E)
 


### PR DESCRIPTION
The face of avy is hard to see in the terminal with base16-shell when `(setq base16-theme-256-color-source 'base16-shell)`

Before (with base16-default-light):

![Screenshot from 2019-06-03 14-51-24](https://user-images.githubusercontent.com/20392677/58782508-6c3cca00-8611-11e9-8bf1-0635e0907450.png)
)
After (with base16-default-light):

![Screenshot from 2019-06-03 14-58-41](https://user-images.githubusercontent.com/20392677/58782572-90001000-8611-11e9-9272-984d5a311f9a.png)

After (with base16-default-dark):

![Screenshot from 2019-06-03 14-56-14](https://user-images.githubusercontent.com/20392677/58782606-a5753a00-8611-11e9-9c69-eb6f880f22b9.png)
