### PR TITLE
fix avy-background-face

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -287,7 +287,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (avy-lead-face-1                              :foreground base00 :background base05)
      (avy-lead-face-2                              :foreground base00 :background base0E)
      (avy-lead-face                                :foreground base00 :background base09)
-     (avy-background-face                          :foreground base01)
+     (avy-background-face                          :foreground base03)
      (avy-goto-char-timer-face                     :inherit highlight)
 
 ;;;; clojure-mode


### PR DESCRIPTION
There is a issue that it would be unreadable when `(setq avy-background t)`, and this will fix it.

Before:

![Screenshot from 2019-06-03 21-50-48](https://user-images.githubusercontent.com/20392677/58807311-61525b80-864a-11e9-81a5-16d7d78970ac.png)

After:

![Screenshot from 2019-06-03 21-52-10](https://user-images.githubusercontent.com/20392677/58807328-69120000-864a-11e9-8e56-0b75cf8cd1d0.png)
