### PR TITLE
Add imenu-list support

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -590,6 +590,12 @@ return the actual color value.  Otherwise return the value unchanged."
      (idris-equals-face                            :inherit font-lock-keyword-face)
      (idris-operator-face                          :inherit font-lock-keyword-face)
 
+;;;; imenu-list
+     (imenu-list-entry-face-0                      :foreground base0A)
+     (imenu-list-entry-face-1                      :foreground base0B)
+     (imenu-list-entry-face-2                      :foreground base0D)
+     (imenu-list-entry-face-3                      :foreground base0F)
+
 ;;;; ivy-mode
      (ivy-current-match                            :foreground base09 :background base01)
      (ivy-minibuffer-match-face-1                  :foreground base0E)


### PR DESCRIPTION
`imenu-list` is hard to see in terminal with a light colorscheme

preview (before then after):
- terminal with base16-default-light
![terminal-light-before](https://user-images.githubusercontent.com/20392677/67916031-6dc5ea80-fbcf-11e9-8331-448100ee7a7a.png)
![terminal-light-after](https://user-images.githubusercontent.com/20392677/67916092-96e67b00-fbcf-11e9-8ab8-367b2f6e2e5f.png)

- terminal with base16-default-dark
![terminal-dark-before](https://user-images.githubusercontent.com/20392677/67916069-87ffc880-fbcf-11e9-8f87-027d333385ca.png)
![terminal-dark-after](https://user-images.githubusercontent.com/20392677/67916099-99e16b80-fbcf-11e9-8630-dd72513fb743.png)

- gui with base16-default-light
![gui-light-before](https://user-images.githubusercontent.com/20392677/67916076-8cc47c80-fbcf-11e9-93cb-f2ef350edd0b.png)
![gui-light-after](https://user-images.githubusercontent.com/20392677/67916100-9c43c580-fbcf-11e9-81d1-e1c0c21a5a50.png)

- gui with base16-default-dark
![gui-dark-before](https://user-images.githubusercontent.com/20392677/67916079-8e8e4000-fbcf-11e9-806b-81171f2e8b61.png)
![gui-dark-after](https://user-images.githubusercontent.com/20392677/67916102-9d74f280-fbcf-11e9-9689-7cab1999eeaf.png)

