### PR TITLE
make the line-number-current-line inherit fringe

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -248,7 +248,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; line-numbers
      (line-number                                  :foreground base03 :background base16-settings-fringe-bg)
-     (line-number-current-line                     :inverse-video t)
+     (line-number-current-line                     :inherit fringe)
 
 ;;;; mode-line
      (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)
@@ -665,7 +665,7 @@ return the actual color value.  Otherwise return the value unchanged."
 ;;;; lsp-ui-doc
      (lsp-ui-doc-header                            :inherit org-document-title)
      (lsp-ui-doc-background                        :background base01)
-     
+
 ;;;; lui-mode
      (lui-button-face                              :foreground base0D)
      (lui-highlight-face                           :background base01)
@@ -891,7 +891,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; tooltip
      (tooltip                                      :background base01 :inherit default)
-     
+
 ;;;; tuareg-mode
      (tuareg-font-lock-governing-face              :weight bold :inherit font-lock-keyword-face)
 


### PR DESCRIPTION
Using the fringe for the `line-number-curret-line` face creates enough contrast between the current line and the rest