### PR TITLE
Add face for dired-filetype-plain

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -353,6 +353,9 @@ return the actual color value.  Otherwise return the value unchanged."
      (diff-file-header                             :background base02)
      (diff-hunk-header                             :foreground base0E :background base01)
 
+;;;; dired
+     (dired-filetype-plain                         :foreground base05 :background base00)
+     
 ;;;; dired+
      (diredp-compressed-file-suffix                :foreground base0D)
      (diredp-dir-heading                           :foreground nil :background nil :inherit heading)


### PR DESCRIPTION
Add dired-filetype-plain using base 16 default.  Note, dired-filetype-face.el defines this face color as DarkSeaGreen1, which is poor contrast for many base16 themes.

Example with base16-atelier-seaside-light.
Before
![seaside-before](https://user-images.githubusercontent.com/484260/105208041-dfa88d80-5b0d-11eb-9e97-de7753299e61.png)

After
![seaside-after](https://user-images.githubusercontent.com/484260/105208429-4af25f80-5b0e-11eb-86d7-aeb5421dc3f1.png)

