### PR TITLE
Handle perspective-mode's selected face

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -808,6 +808,9 @@ return the actual color value.  Otherwise return the value unchanged."
 ;;;; paren-face-mode
      (paren-face                                   :foreground base04 :background nil)
 
+;;;; perspective-mode
+     (persp-selected-face                          :foreground base0C)
+
 ;;;; popup
      (popup-face                                   :foreground base05 :background base02)
      (popup-isearch-match                          :foreground base00 :background base0B)


### PR DESCRIPTION
A small change so that perspective-mode does not look out of place:

<img width="70" alt="Screenshot 2021-08-05 at 09 08 09" src="https://user-images.githubusercontent.com/2331765/128299865-5db68114-cdef-4769-8368-9378cef73949.png">
