### PR TITLE
Fix `font-lock-comment-delimiter-face` color to fit the base16 specification

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -223,7 +223,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; font-lock
      (font-lock-builtin-face                       :foreground base0C)
-     (font-lock-comment-delimiter-face             :foreground base02)
+     (font-lock-comment-delimiter-face             :foreground base03)
      (font-lock-comment-face                       :foreground base03)
      (font-lock-constant-face                      :foreground base09)
      (font-lock-doc-face                           :foreground base04)


### PR DESCRIPTION
Fixed `font-lock-comment-delimiter-face` so that it is actually visible and fits the base16 spec. Fixes #114.

Before:
![2021-12-25:20:53:35](https://user-images.githubusercontent.com/31081543/147392741-94ee9d00-c0fe-43f8-b6d4-0ad0d13da159.png)
After:
![2021-12-25:20:54:04](https://user-images.githubusercontent.com/31081543/147392743-be697873-f5f5-4deb-9702-b35a5d4b1fca.png)
