### PR TITLE
Add tab-line support

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -257,6 +257,13 @@ return the actual color value.  Otherwise return the value unchanged."
      (mode-line-highlight                          :foreground base0E :box nil :weight bold)
      (mode-line-inactive                           :foreground base03 :background base01 :box nil)
 
+;;;; tab-line
+     (tab-line                                     :background base16-settings-fringe-bg)
+     (tab-line-tab                                 :background base16-settings-fringe-bg)
+     (tab-line-tab-inactive                        :background base16-settings-fringe-bg)
+     (tab-line-tab-current                         :foreground base05 :background base00)
+     (tab-line-highlight                           :distant-foreground base05 :background base02)
+
 ;;; Third-party
 
 ;;;; anzu-mode
@@ -933,14 +940,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (whitespace-space-after-tab                   :foreground base08 :background base0A)
      (whitespace-space-before-tab                  :foreground base08 :background base09)
      (whitespace-tab                               :foreground base03 :background base01)
-     (whitespace-trailing                          :foreground base0A :background base08)
-
-;;;; tab-line
-     (tab-line                                     :background base16-settings-fringe-bg)
-     (tab-line-tab                                 :background base16-settings-fringe-bg)
-     (tab-line-tab-inactive                        :background base16-settings-fringe-bg)
-     (tab-line-tab-current                         :foreground base05 :background base00)
-     (tab-line-highlight                           :distant-foreground base05 :background base02)))
+     (whitespace-trailing                          :foreground base0A :background base08)))
 
   ;; Anything leftover that doesn't fall neatly into a face goes here.
   (let ((base00 (plist-get theme-colors :base00))

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -934,6 +934,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (whitespace-space-before-tab                  :foreground base08 :background base09)
      (whitespace-tab                               :foreground base03 :background base01)
      (whitespace-trailing                          :foreground base0A :background base08)
+
 ;;;; tab-line
      (tab-line                                     :background base16-settings-fringe-bg)
      (tab-line-tab                                 :background base16-settings-fringe-bg)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -248,7 +248,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; line-numbers
      (line-number                                  :foreground base03 :background base16-settings-fringe-bg)
-     (line-number-current-line                     :inverse-video t)
+     (line-number-current-line                     :inherit fringe)
 
 ;;;; mode-line
      (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)
@@ -665,7 +665,7 @@ return the actual color value.  Otherwise return the value unchanged."
 ;;;; lsp-ui-doc
      (lsp-ui-doc-header                            :inherit org-document-title)
      (lsp-ui-doc-background                        :background base01)
-     
+
 ;;;; lui-mode
      (lui-button-face                              :foreground base0D)
      (lui-highlight-face                           :background base01)
@@ -891,7 +891,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; tooltip
      (tooltip                                      :background base01 :inherit default)
-     
+
 ;;;; tuareg-mode
      (tuareg-font-lock-governing-face              :weight bold :inherit font-lock-keyword-face)
 

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -933,7 +933,13 @@ return the actual color value.  Otherwise return the value unchanged."
      (whitespace-space-after-tab                   :foreground base08 :background base0A)
      (whitespace-space-before-tab                  :foreground base08 :background base09)
      (whitespace-tab                               :foreground base03 :background base01)
-     (whitespace-trailing                          :foreground base0A :background base08)))
+     (whitespace-trailing                          :foreground base0A :background base08)
+;;;; tab-line
+     (tab-line                                     :background base16-settings-fringe-bg)
+     (tab-line-tab                                 :background base16-settings-fringe-bg)
+     (tab-line-tab-inactive                        :background base16-settings-fringe-bg)
+     (tab-line-tab-current                         :foreground base05 :background base00)
+     (tab-line-highlight                           :foreground base05 :background base01)))
 
   ;; Anything leftover that doesn't fall neatly into a face goes here.
   (let ((base00 (plist-get theme-colors :base00))

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -248,7 +248,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; line-numbers
      (line-number                                  :foreground base03 :background base16-settings-fringe-bg)
-     (line-number-current-line                     :inherit fringe)
+     (line-number-current-line                     :inverse-video t)
 
 ;;;; mode-line
      (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -939,7 +939,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (tab-line-tab                                 :background base16-settings-fringe-bg)
      (tab-line-tab-inactive                        :background base16-settings-fringe-bg)
      (tab-line-tab-current                         :foreground base05 :background base00)
-     (tab-line-highlight                           :foreground base05 :background base01)))
+     (tab-line-highlight                           :distant-foreground base05 :background base02)))
 
   ;; Anything leftover that doesn't fall neatly into a face goes here.
   (let ((base00 (plist-get theme-colors :base00))


### PR DESCRIPTION
Support for tab-line-mode:
Tabs use the same face as the fringe except for the current-tab, which uses the default face.
IMHO it creates a nice way of connecting the tab-line with the buffer.

You can ignore commit e2f21a1. I don't know why it is still here ;-)

Best, /PA