### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/emacs
+* @tinted-theming/emacs

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,4 @@
-name: Update with the latest base16 colorschemes
+name: Update with the latest colorschemes
 on:
   workflow_dispatch:
   schedule:
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Update with the latest base16-project colorschemes
+          commit_message: Update with the latest tinted-theming colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (C) 2012 Chris Kempson (http://chriskempson.com)
 Copyright (C) 2016 Kaleb Elwert
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.org
+++ b/README.org
@@ -3,13 +3,13 @@
 
 * Base16 themes for Emacs
 
-[[https://github.com/base16-project/base16][Base16]] provides carefully chosen syntax highlighting and a default set
-of sixteen colors suitable for a wide range of applications. Base16 is
-not a single theme but a set of guidelines with numerous
+[[https://github.com/tinted-theming/home][Tinted Theming]] provides carefully chosen syntax highlighting and a default set
+of sixteen colors suitable for a wide range of applications. Tinted
+Theming is not a single theme but a set of guidelines with numerous
 implementations.
 
 This repository contains the Emacs templates and [[http://melpa.org/#/base16-theme][MELPA]]. It can be built
-by using one of the builders listed on the main Base16 page.
+by using one of the builders listed on the main Tinted Theming page.
 
 If you notice anything that looks strange or if this repo is missing
 any scheme updates, please feel free to open an issue or submit a pull
@@ -89,7 +89,7 @@ Similar to other config values, make sure this is set before calling
 
 ** Previews
 
-Theme previews can be found [[https://base16-project.github.io/base16-emacs/][here]].
+Theme previews can be found [[https://tinted-theming.github.io/base16-emacs/][here]].
 
 It is recommended to generate screenshots by adding the gh-pages branch as a
 subtree (=git worktree add -B gh-pages gh-pages origin/gh-pages=) then

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -4,11 +4,11 @@
 ;;         Neil Bhakta
 ;; Maintainer: Kaleb Elwert <belak@coded.io>
 ;; Version: 3.0
-;; Homepage: https://github.com/base16-project/base16-emacs
+;; Homepage: https://github.com/tinted-theming/base16-emacs
 
 ;;; Commentary:
 ;; base16-theme is a collection of themes built around the base16
-;; concept (https://github.com/base16-project/base16).  All themes are
+;; concept (https://github.com/tinted-theming/base16).  All themes are
 ;; generated from the official set of color schemes and the templates
 ;; which are included in this repo.
 

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,7 +1,7 @@
 ;; base16-{{scheme-slug}}-theme.el -- A base16 colorscheme
 
 ;;; Commentary:
-;; Base16: (https://github.com/base16-project/base16)
+;; Base16: (https://github.com/tinted-theming/base16)
 
 ;;; Authors:
 ;; Scheme: {{scheme-author}}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.