### PR TITLE
tab-bar support

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -257,6 +257,13 @@ return the actual color value.  Otherwise return the value unchanged."
      (mode-line-highlight                          :foreground base0E :box nil :weight bold)
      (mode-line-inactive                           :foreground base03 :background base01 :box nil)
 
+;;;; tab-bar
+    (tab-bar                                       :background base16-settings-fringe-bg)
+    (tab-bar-tab                                   :foreground base09 :background base01)
+    (tab-bar-tab-inactive                          :foreground base06 :background base01)
+    (tab-bar-tab-group-current                     :foreground base05 :background base00)
+    (tab-bar-tab-group-inactive                    :background base16-settings-fringe-bg)
+
 ;;;; tab-line
      (tab-line                                     :background base16-settings-fringe-bg)
      (tab-line-tab                                 :background base16-settings-fringe-bg)


### PR DESCRIPTION
Current status:
<img width="588" alt="image" src="https://user-images.githubusercontent.com/950087/206057377-5d655f06-fac8-4c9b-a637-56a5a5c330c8.png">


After the change (feel free to adjust the colours)

twilight:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/950087/206056937-d291d1aa-3937-49a7-ab71-a5ea063de569.png">

tomorrow night:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/950087/206056996-463745aa-d5e5-44ea-a711-213289fe3ec5.png">

solarized:
<img width="627" alt="image" src="https://user-images.githubusercontent.com/950087/206057145-3e7db31f-c7ab-4487-8174-4753c7541d32.png">

Fixes: https://github.com/tinted-theming/base16-emacs/issues/132