### PR TITLE
Fix incorrect nil values for background and foreground colors

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -191,7 +191,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (default                                      :foreground base05 :background base00)
      (fringe                                       :background base16-settings-fringe-bg)
      (gui-element                                  :background base01)
-     (header-line                                  :foreground base0E :background nil :inherit mode-line)
+     (header-line                                  :foreground base0E :background unspecified :inherit mode-line)
      (highlight                                    :background base01)
      (link                                         :foreground base0D :underline t)
      (link-visited                                 :foreground base0E :underline t)
@@ -252,7 +252,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; mode-line
      (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)
-     (mode-line-buffer-id                          :foreground base0B :background nil)
+     (mode-line-buffer-id                          :foreground base0B :background unspecified)
      (mode-line-emphasis                           :foreground base06 :slant italic)
      (mode-line-highlight                          :foreground base0E :box nil :weight bold)
      (mode-line-inactive                           :foreground base03 :background base01 :box nil)
@@ -372,55 +372,55 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; dired+
      (diredp-compressed-file-suffix                :foreground base0D)
-     (diredp-dir-heading                           :foreground nil :background nil :inherit heading)
-     (diredp-dir-priv                              :foreground base0C :background nil)
-     (diredp-exec-priv                             :foreground base0D :background nil)
-     (diredp-executable-tag                        :foreground base08 :background nil)
+     (diredp-dir-heading                           :foreground unspecified :background unspecified :inherit heading)
+     (diredp-dir-priv                              :foreground base0C :background unspecified)
+     (diredp-exec-priv                             :foreground base0D :background unspecified)
+     (diredp-executable-tag                        :foreground base08 :background unspecified)
      (diredp-file-name                             :foreground base0A)
      (diredp-file-suffix                           :foreground base0B)
-     (diredp-flag-mark-line                        :background nil :inherit highlight)
+     (diredp-flag-mark-line                        :background unspecified :inherit highlight)
      (diredp-ignored-file-name                     :foreground base04)
-     (diredp-link-priv                             :foreground base0E :background nil)
+     (diredp-link-priv                             :foreground base0E :background unspecified)
      (diredp-mode-line-flagged                     :foreground base08)
      (diredp-mode-line-marked                      :foreground base0B)
-     (diredp-no-priv                               :background nil)
+     (diredp-no-priv                               :background unspecified)
      (diredp-number                                :foreground base0A)
-     (diredp-other-priv                            :foreground base0E :background nil)
-     (diredp-rare-priv                             :foreground base08 :background nil)
-     (diredp-read-priv                             :foreground base0B :background nil)
+     (diredp-other-priv                            :foreground base0E :background unspecified)
+     (diredp-rare-priv                             :foreground base08 :background unspecified)
+     (diredp-read-priv                             :foreground base0B :background unspecified)
      (diredp-symlink                               :foreground base0E)
-     (diredp-write-priv                            :foreground base0A :background nil)
+     (diredp-write-priv                            :foreground base0A :background unspecified)
 
 ;;;; diredfl
      (diredfl-autofile-name                        :foreground base0E)
      (diredfl-compressed-file-name                 :foreground base0A)
      (diredfl-compressed-file-suffix               :foreground base0D)
      (diredfl-date-time                            :foreground base0C :weight light)
-     (diredfl-deletion                             :foreground nil :background base08)
+     (diredfl-deletion                             :foreground unspecified :background base08)
      (diredfl-deletion-file-name                   :foreground base00 :background base08 :weight bold)
-     (diredfl-dir-heading                          :foreground nil :background nil :inherit heading :weight bold)
+     (diredfl-dir-heading                          :foreground unspecified :background unspecified :inherit heading :weight bold)
      (diredfl-dir-name                             :foreground base0D)
-     (diredfl-dir-priv                             :foreground base0D :background nil)
-     (diredfl-exec-priv                            :foreground base08 :background nil)
-     (diredfl-executable-tag                       :foreground base08 :background nil)
+     (diredfl-dir-priv                             :foreground base0D :background unspecified)
+     (diredfl-exec-priv                            :foreground base08 :background unspecified)
+     (diredfl-executable-tag                       :foreground base08 :background unspecified)
      (diredfl-file-name                            :foreground base0A)
      (diredfl-file-suffix                          :foreground base0B)
      (diredfl-flag-mark                            :foreground base09 :weight bold)
-     (diredfl-flag-mark-line                       :background nil :inherit highlight)
+     (diredfl-flag-mark-line                       :background unspecified :inherit highlight)
      (diredfl-ignored-file-name                    :foreground base04)
-     (diredfl-link-priv                            :foreground base0E :background nil)
-     (diredfl-no-priv                              :background nil)
+     (diredfl-link-priv                            :foreground base0E :background unspecified)
+     (diredfl-no-priv                              :background unspecified)
      (diredfl-number                               :foreground base0A)
-     (diredfl-other-priv                           :foreground base0E :background nil)
-     (diredfl-rare-priv                            :foreground base0F :background nil)
-     (diredfl-read-priv                            :foreground base0B :background nil)
+     (diredfl-other-priv                           :foreground base0E :background unspecified)
+     (diredfl-rare-priv                            :foreground base0F :background unspecified)
+     (diredfl-read-priv                            :foreground base0B :background unspecified)
      (diredfl-symlink                              :foreground base0E)
      (diredfl-tagged-autofile-name                 :foreground base05)
-     (diredfl-write-priv                           :foreground base0A :background nil)
+     (diredfl-write-priv                           :foreground base0A :background unspecified)
 
 ;;;; doom-modeline
      (doom-modeline-eldoc-bar                      :background base0B)
-     (doom-modeline-inactive-bar                   :background nil) ; transparent
+     (doom-modeline-inactive-bar                   :background unspecified) ; transparent
      (doom-modeline-bar                            :background base0D)
 
 ;;;; ediff-mode
@@ -504,20 +504,20 @@ return the actual color value.  Otherwise return the value unchanged."
      (git-gutter-fr:modified                       :foreground base0E)
 
 ;;;; gnus
-     (gnus-cite-1                                  :foreground nil :inherit outline-1)
-     (gnus-cite-2                                  :foreground nil :inherit outline-2)
-     (gnus-cite-3                                  :foreground nil :inherit outline-3)
-     (gnus-cite-4                                  :foreground nil :inherit outline-4)
-     (gnus-cite-5                                  :foreground nil :inherit outline-5)
-     (gnus-cite-6                                  :foreground nil :inherit outline-6)
-     (gnus-cite-7                                  :foreground nil :inherit outline-7)
-     (gnus-cite-8                                  :foreground nil :inherit outline-8)
+     (gnus-cite-1                                  :foreground unspecified :inherit outline-1)
+     (gnus-cite-2                                  :foreground unspecified :inherit outline-2)
+     (gnus-cite-3                                  :foreground unspecified :inherit outline-3)
+     (gnus-cite-4                                  :foreground unspecified :inherit outline-4)
+     (gnus-cite-5                                  :foreground unspecified :inherit outline-5)
+     (gnus-cite-6                                  :foreground unspecified :inherit outline-6)
+     (gnus-cite-7                                  :foreground unspecified :inherit outline-7)
+     (gnus-cite-8                                  :foreground unspecified :inherit outline-8)
      ;; there are several more -cite- faces...
      (gnus-header-content                          :inherit message-header-other)
      (gnus-header-subject                          :inherit message-header-subject)
      (gnus-header-from                             :foreground base09 :weight bold :inherit message-header-other-face)
      (gnus-header-name                             :inherit message-header-name)
-     (gnus-button                                  :foreground nil :inherit link)
+     (gnus-button                                  :foreground unspecified :inherit link)
      (gnus-signature                               :inherit font-lock-comment-face)
 
      (gnus-summary-normal-unread                   :foreground base0D :weight normal)
@@ -531,28 +531,28 @@ return the actual color value.  Otherwise return the value unchanged."
      (gnus-summary-high-read                       :foreground base0B :weight normal)
      (gnus-summary-high-ancient                    :foreground base0B :weight normal)
      (gnus-summary-high-ticked                     :foreground base09 :weight normal)
-     (gnus-summary-cancelled                       :foreground base08 :background nil :weight normal)
+     (gnus-summary-cancelled                       :foreground base08 :background unspecified :weight normal)
 
      (gnus-group-mail-low                          :foreground base04)
      (gnus-group-mail-low-empty                    :foreground base04)
-     (gnus-group-mail-1                            :foreground nil :weight normal :inherit outline-1)
-     (gnus-group-mail-2                            :foreground nil :weight normal :inherit outline-2)
-     (gnus-group-mail-3                            :foreground nil :weight normal :inherit outline-3)
-     (gnus-group-mail-4                            :foreground nil :weight normal :inherit outline-4)
-     (gnus-group-mail-5                            :foreground nil :weight normal :inherit outline-5)
-     (gnus-group-mail-6                            :foreground nil :weight normal :inherit outline-6)
+     (gnus-group-mail-1                            :foreground unspecified :weight normal :inherit outline-1)
+     (gnus-group-mail-2                            :foreground unspecified :weight normal :inherit outline-2)
+     (gnus-group-mail-3                            :foreground unspecified :weight normal :inherit outline-3)
+     (gnus-group-mail-4                            :foreground unspecified :weight normal :inherit outline-4)
+     (gnus-group-mail-5                            :foreground unspecified :weight normal :inherit outline-5)
+     (gnus-group-mail-6                            :foreground unspecified :weight normal :inherit outline-6)
      (gnus-group-mail-1-empty                      :foreground base04 :inherit gnus-group-mail-1)
      (gnus-group-mail-2-empty                      :foreground base04 :inherit gnus-group-mail-2)
      (gnus-group-mail-3-empty                      :foreground base04 :inherit gnus-group-mail-3)
      (gnus-group-mail-4-empty                      :foreground base04 :inherit gnus-group-mail-4)
      (gnus-group-mail-5-empty                      :foreground base04 :inherit gnus-group-mail-5)
      (gnus-group-mail-6-empty                      :foreground base04 :inherit gnus-group-mail-6)
-     (gnus-group-news-1                            :foreground nil :weight normal :inherit outline-5)
-     (gnus-group-news-2                            :foreground nil :weight normal :inherit outline-6)
-     (gnus-group-news-3                            :foreground nil :weight normal :inherit outline-7)
-     (gnus-group-news-4                            :foreground nil :weight normal :inherit outline-8)
-     (gnus-group-news-5                            :foreground nil :weight normal :inherit outline-1)
-     (gnus-group-news-6                            :foreground nil :weight normal :inherit outline-2)
+     (gnus-group-news-1                            :foreground unspecified :weight normal :inherit outline-5)
+     (gnus-group-news-2                            :foreground unspecified :weight normal :inherit outline-6)
+     (gnus-group-news-3                            :foreground unspecified :weight normal :inherit outline-7)
+     (gnus-group-news-4                            :foreground unspecified :weight normal :inherit outline-8)
+     (gnus-group-news-5                            :foreground unspecified :weight normal :inherit outline-1)
+     (gnus-group-news-6                            :foreground unspecified :weight normal :inherit outline-2)
      (gnus-group-news-1-empty                      :foreground base04 :inherit gnus-group-news-1)
      (gnus-group-news-2-empty                      :foreground base04 :inherit gnus-group-news-2)
      (gnus-group-news-3-empty                      :foreground base04 :inherit gnus-group-news-3)
@@ -567,12 +567,12 @@ return the actual color value.  Otherwise return the value unchanged."
      (grep-context-face                            :foreground base04)
      (grep-error-face                              :foreground base08 :weight bold :underline t)
      (grep-hit-face                                :foreground base0D)
-     (grep-match-face                              :foreground nil :background nil :inherit match)
+     (grep-match-face                              :foreground unspecified :background unspecified :inherit match)
 
 ;;;; helm
      (helm-M-x-key                                 :foreground base0C)
      (helm-action                                  :foreground base05)
-     (helm-buffer-directory                        :foreground base04 :background nil :weight bold)
+     (helm-buffer-directory                        :foreground base04 :background unspecified :weight bold)
      (helm-buffer-file                             :foreground base0C)
      (helm-buffer-not-saved                        :foreground base08)
      (helm-buffer-process                          :foreground base03)
@@ -584,7 +584,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (helm-ff-executable                           :foreground base0B)
      (helm-ff-file                                 :inherit default)
      (helm-ff-invalid-symlink                      :inherit dired-warning)
-     (helm-ff-prefix                               :foreground nil :background nil)
+     (helm-ff-prefix                               :foreground unspecified :background unspecified)
      (helm-ff-symlink                              :inherit dired-symlink)
      (helm-ff-suid                                 :foreground base08)
      (helm-ff-dotted-symlink-directory             :foreground base09 :background base03)
@@ -605,8 +605,8 @@ return the actual color value.  Otherwise return the value unchanged."
      (helm-header                                  :foreground base0A :background base00 :underline nil)
      (helm-match                                   :foreground base0A)
      (helm-moccur-buffer                           :foreground base0C)
-     (helm-selection                               :foreground nil :background base02 :underline nil)
-     (helm-selection-line                          :foreground nil :background base02)
+     (helm-selection                               :foreground unspecified :background base02 :underline nil)
+     (helm-selection-line                          :foreground unspecified :background base02)
      (helm-separator                               :foreground base02)
      (helm-source-header                           :foreground base05 :background base01 :weight bold)
      (helm-visible-mark                            :foreground base00 :background base0B)
@@ -686,7 +686,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; js2-mode
      (js2-warning-face                             :underline base09)
-     (js2-error-face                               :foreground nil :underline base08)
+     (js2-error-face                               :foreground unspecified :underline base08)
      (js2-external-variable-face                   :foreground base0E)
      (js2-function-param-face                      :foreground base0D)
      (js2-instance-member-face                     :foreground base0D)
@@ -694,7 +694,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; js3-mode
      (js3-warning-face                             :underline base09)
-     (js3-error-face                               :foreground nil :underline base08)
+     (js3-error-face                               :foreground unspecified :underline base08)
      (js3-external-variable-face                   :foreground base0E)
      (js3-function-param-face                      :foreground base0D)
      (js3-jsdoc-tag-face                           :foreground base09)
@@ -756,26 +756,26 @@ return the actual color value.  Otherwise return the value unchanged."
      (magit-signature-untrusted                    :foreground base0C)
      (magit-tag                                    :foreground base05)
 ;;;; mark-multiple
-     (mm/master-face                               :foreground nil :background nil :inherit region)
-     (mm/mirror-face                               :foreground nil :background nil :inherit region)
+     (mm/master-face                               :foreground unspecified :background unspecified :inherit region)
+     (mm/mirror-face                               :foreground unspecified :background unspecified :inherit region)
 
 ;;;; markdown-mode
      (markdown-url-face                            :inherit link)
      (markdown-link-face                           :foreground base0D :underline t)
 
 ;;;; message-mode
-     (message-header-other                         :foreground nil :background nil :weight normal)
+     (message-header-other                         :foreground unspecified :background unspecified :weight normal)
      (message-header-subject                       :foreground base0A :weight bold :inherit message-header-other)
      (message-header-to                            :foreground base09 :weight bold :inherit message-header-other)
-     (message-header-cc                            :foreground nil :inherit message-header-to)
-     (message-header-name                          :foreground base0D :background nil)
-     (message-header-newsgroups                    :foreground base0C :background nil :slant normal)
+     (message-header-cc                            :foreground unspecified :inherit message-header-to)
+     (message-header-name                          :foreground base0D :background unspecified)
+     (message-header-newsgroups                    :foreground base0C :background unspecified :slant normal)
      (message-separator                            :foreground base0E)
 
 ;;;; mic-paren
-     (paren-face-match                             :foreground nil :background nil :inherit show-paren-match)
-     (paren-face-mismatch                          :foreground nil :background nil :inherit show-paren-mismatch)
-     (paren-face-no-match                          :foreground nil :background nil :inherit show-paren-mismatch)
+     (paren-face-match                             :foreground unspecified :background unspecified :inherit show-paren-match)
+     (paren-face-mismatch                          :foreground unspecified :background unspecified :inherit show-paren-mismatch)
+     (paren-face-no-match                          :foreground unspecified :background unspecified :inherit show-paren-mismatch)
 
 ;;;; mmm-mode
      (mmm-code-submode-face                        :background base03)
@@ -783,7 +783,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (mmm-output-submode-face                      :background base03)
 
 ;;;; notmuch
-	 (notmuch-message-summary-face                 :foreground base04 :background nil)
+	 (notmuch-message-summary-face                 :foreground base04 :background unspecified)
 	 (notmuch-search-count                         :foreground base04)
 	 (notmuch-search-date                          :foreground base04)
 	 (notmuch-search-flagged-face                  :foreground base08)
@@ -849,7 +849,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (org-warning                                  :foreground base08 :weight bold)
 
 ;;;; paren-face-mode
-     (paren-face                                   :foreground base04 :background nil)
+     (paren-face                                   :foreground base04 :background unspecified)
 
 ;;;; perspective-mode
      (persp-selected-face                          :foreground base0C)
@@ -885,7 +885,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (rainbow-delimiters-depth-9-face              :foreground base05)
 
 ;;;; regex-tool
-     (regex-tool-matched-face                      :foreground nil :background nil :inherit match)
+     (regex-tool-matched-face                      :foreground unspecified :background unspecified :inherit match)
 
 ;;;; rhtml-mode
      (erb-delim-face                               :background base03)
@@ -897,8 +897,8 @@ return the actual color value.  Otherwise return the value unchanged."
      (erb-comment-delim-face                       :background base03)
 
 ;;;; sh-mode
-     (sh-heredoc                                   :foreground nil :weight normal :inherit font-lock-string-face)
-     (sh-quoted-exec                               :foreground nil :inherit font-lock-preprocessor-face)
+     (sh-heredoc                                   :foreground unspecified :weight normal :inherit font-lock-string-face)
+     (sh-quoted-exec                               :foreground unspecified :inherit font-lock-preprocessor-face)
 
 ;;;; show-paren-mode
      (show-paren-match                             :foreground base01 :background base0D)
@@ -1010,7 +1010,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (w3m-tab-unselected-retrieving                :foreground base03 :background base01)
 
 ;;;; which-func-mode
-     (which-func                                   :foreground base0D :background nil :weight bold)
+     (which-func                                   :foreground base0D :background unspecified :weight bold)
 
 ;;;; whitespace-mode
      (whitespace-empty                             :foreground base08 :background base0A)


### PR DESCRIPTION
Emacs (29.1) issues warnings when loading a theme, such as:
`Warning: setting attribute ‘:background’ of face ‘header-line’: nil value is invalid, use ‘unspecified’ instead.`
or
`Warning: setting attribute ‘:foreground’ of face ‘message-header-cc’: nil value is invalid, use ‘unspecified’ instead.`

I replaced all occurrences of `nil` with `unspecified` for `:background` and `:foreground` attributes of faces.

Everything works as expected, and the warnings are gone.