### PR TITLE
Style the `org-verbatim` face

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -853,6 +853,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (org-table                                    :foreground base0E)
      (org-todo                                     :foreground base08 :background base01)
      (org-upcoming-deadline                        :foreground base09)
+     (org-verbatim                                 :foreground base0A)
      (org-warning                                  :foreground base08 :weight bold)
 
 ;;;; paren-face-mode


### PR DESCRIPTION
Similar to `org-code`, `org-verbatim` is used to highlight fixed-width text and code samples. It being the default foreground means users who have set `org-hide-emphasis-markers` to non-nil won't see any highlighting at all (unless using `variable-pitch-mode` or something similar). I figured using the same face might be a good first step, as most people I know don't really differentiate between code and verbatim and use them for the same purpose. But anything trumps it not being styled :smiley: 

Before (screenshots without `org-hide-emphasis-markers`):
![before](https://github.com/user-attachments/assets/62c1b325-2a12-4738-b9d8-56fcabc3aa8e)

After:
![after](https://github.com/user-attachments/assets/5c5f53d0-d38b-4815-b9f7-076e22f12ca7)