### PR TITLE
reduce the use of red color

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -230,14 +230,14 @@ return the actual color value.  Otherwise return the value unchanged."
      (font-lock-doc-face                           :foreground base04)
      (font-lock-doc-string-face                    :foreground base03)
      (font-lock-function-name-face                 :foreground base0D)
-     (font-lock-keyword-face                       :foreground base0E)
+     (font-lock-keyword-face                       :foreground base08)
      (font-lock-negation-char-face                 :foreground base0B)
      (font-lock-preprocessor-face                  :foreground base0D)
      (font-lock-regexp-grouping-backslash          :foreground base0A)
      (font-lock-regexp-grouping-construct          :foreground base0E)
      (font-lock-string-face                        :foreground base0B)
      (font-lock-type-face                          :foreground base0A)
-     (font-lock-variable-name-face                 :foreground base08)
+     (font-lock-variable-name-face                 :foreground base0E)
      (font-lock-warning-face                       :foreground base08)
 
 ;;;; isearch
@@ -253,7 +253,7 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;;; mode-line
      (mode-line                                    :foreground base16-settings-mode-line-fg :background base02 :box base16-settings-mode-line-box)
-     (mode-line-buffer-id                          :foreground base0B :background unspecified)
+     (mode-line-buffer-id                          :foreground base05 :background unspecified)
      (mode-line-emphasis                           :foreground base06 :slant italic)
      (mode-line-highlight                          :foreground base0E :box nil :weight bold)
      (mode-line-inactive                           :foreground base03 :background base01 :box nil)
@@ -330,7 +330,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (company-tooltip                              :inherit tooltip)
      (company-scrollbar-bg                         :background base07)
      (company-scrollbar-fg                         :background base04)
-     (company-tooltip-annotation                   :foreground base08)
+     (company-tooltip-annotation                   :foreground base03)
      (company-tooltip-common                       :inherit font-lock-constant-face)
      (company-tooltip-selection                    :background base02 :inherit font-lock-function-name-face)
      (company-tooltip-search                       :inherit match)


### PR DESCRIPTION
use white color for the buffer id. In solarized-light

before

![solarized-before](https://github.com/user-attachments/assets/27a30ac7-996d-49d9-8e09-cb473d64211c)

after

![solarized-after](https://github.com/user-attachments/assets/b8b7fc73-4b6d-44a2-9188-8d27cae8befb)

use red color for keywords rather than for tokens. In gruvbox-dark-hard

before

![before](https://github.com/user-attachments/assets/dffbd55a-bf7a-4d7e-9e4a-022cf760b604)

after

![after](https://github.com/user-attachments/assets/a0c7ea16-83bd-4c4d-9402-f84564972915)
