### PR TITLE
Use base02 for `magit-diff-hunk-heading-highlight`

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -734,7 +734,7 @@ return the actual color value.  Otherwise return the value unchanged."
      (magit-hunk-heading                           :background base03)
      (magit-hunk-heading-highlight                 :background base03)
      (magit-diff-hunk-heading                      :background base01)
-     (magit-diff-hunk-heading-highlight            :background base01)
+     (magit-diff-hunk-heading-highlight            :background base02)
      (magit-item-highlight                         :background base01)
      (magit-log-author                             :foreground base0D)
      (magit-process-ng                             :foreground base08 :inherit magit-section-heading)


### PR DESCRIPTION
The `-highlight` face is used for the currently selected hunk in the magit diff and revision views. It should be distinct from the non `- highlight` font to aid in naviation.

Per [the guidelines](https://github.com/chriskempson/base16/blob/main/ styling.md), base02 is to be used for "Selection background," which seems apropos to me. It also looks much better in my emacs setup using base16-framer, for whatever that's worth.

Rendering 1d48474c3c07521276f4e7d73317a654997b4381 in my emacs:
### Before
The point is on the header line for the first hunk, but there's no visual differentiation of the hunks.
<img width="716" alt="image" src="https://github.com/user-attachments/assets/e8299f3c-fee5-41f1-a7c3-507e1e1b5dd1" />

### After
Now the header for the first hunk is higlighted.
<img width="716" alt="image" src="https://github.com/user-attachments/assets/b2dfcd09-afe5-4025-bc55-ae15b827123c" />
