### PR TITLE
Add themes for corfu

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -340,6 +340,12 @@ return the actual color value.  Otherwise return the value unchanged."
      (company-preview-search                       :inherit match)
      (company-echo-common                          :inherit secondary-selection)
 
+;;;; corfu
+     (corfu-default                                :inherit tooltip)
+     (corfu-current                                :background base02 :inherit font-lock-function-name-face)
+     (corfu-bar                                    :background base05)
+     (corfu-border                                 :background base04)
+
 ;;;; cperl-mode
      (cperl-array-face                             :weight bold :inherit font-lock-variable-name-face)
      (cperl-hash-face                              :weight bold :slant italic :inherit font-lock-variable-name-face)


### PR DESCRIPTION
Add nicer colors to displaty in corfu frames. Here's what they look like with gruvbox-dark-pale:

<img width="704" alt="Screenshot 2025-01-07 at 17 59 31" src="https://github.com/user-attachments/assets/7fd7c58e-4b33-424d-86aa-b0b53d8c836d" />


