### PR TITLE
Support AsciiDoc faces (adoc-mode)

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -274,13 +274,13 @@ return the actual color value.  Otherwise return the value unchanged."
 
 ;;; Third-party
 
-;;;; anzu-mode
-     (anzu-mode-line                               :foreground base0E)
-
 ;;;; adoc-mode
      (adoc-gen-face                                :foreground base0C)
      (adoc-verbatim-face                           :foreground base0A)
      (adoc-meta-face                               :foreground base03)
+
+;;;; anzu-mode
+     (anzu-mode-line                               :foreground base0E)
 
 ;;;; auctex
      (font-latex-bold-face                         :foreground base0B)

--- a/base16-theme.el
+++ b/base16-theme.el
@@ -277,6 +277,11 @@ return the actual color value.  Otherwise return the value unchanged."
 ;;;; anzu-mode
      (anzu-mode-line                               :foreground base0E)
 
+;;;; adoc-mode
+     (adoc-gen-face                                :foreground base0C)
+     (adoc-verbatim-face                           :foreground base0A)
+     (adoc-meta-face                               :foreground base03)
+
 ;;;; auctex
      (font-latex-bold-face                         :foreground base0B)
      (font-latex-doctex-documentation-face         :background base03)


### PR DESCRIPTION
The `adoc-mode` for AsciiDoc documentation defines some of its faces with fixed colors, which -- depending on the specific Emacs theme -- visually clashes a bit. I've styled the three faces I commonly see looking out of place when writing AsciiDoc using various base16 themes. See the screenshots.

`base16-black-metal-dark-funeral` before:
![2025-05-23-151818_1098x308_scrot](https://github.com/user-attachments/assets/fd6d81d5-832a-46c5-8d90-7bbe6e1baf39)

after:
![2025-05-23-151955_1055x278_scrot](https://github.com/user-attachments/assets/9fc433fc-cdee-42f2-ae2f-e09aa8d34db1)

`base16-solarized-dark` before:
![2025-05-23-152016_1063x279_scrot](https://github.com/user-attachments/assets/a2628f12-4572-4695-a52d-a5f184aa9db2)

after:
![2025-05-23-152044_1064x282_scrot](https://github.com/user-attachments/assets/2a5a392a-e5d2-46d9-ab29-9ffefacd75de)
