### PR TITLE
Style the `help-key-binding` face

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -240,6 +240,9 @@ return the actual color value.  Otherwise return the value unchanged."
      (font-lock-variable-name-face                 :foreground base08)
      (font-lock-warning-face                       :foreground base08)
 
+;;;; help buffers
+     (help-key-binding                             :foreground base05 :background base01 :box (:line-width 1 :color base05) :inherit fixed-pitch)
+
 ;;;; isearch
      (match                                        :foreground base0D :background base01 :inverse-video t)
      (isearch                                      :foreground base0A :background base01 :inverse-video t)


### PR DESCRIPTION
This changes the default look of key bindings/shortcuts in Emacs' help menus according to base16 colors.

### base16-black-metal-immortal
Before:
![2025-06-08-175847_597x190_scrot](https://github.com/user-attachments/assets/910f7286-ddc2-4216-84fa-1b19d2f69ee0)

After:
![2025-06-08-175642_654x198_scrot](https://github.com/user-attachments/assets/e11bd766-2b49-4acc-af88-0233afc2cb79)

### base16-greenscreen
Before:
![2025-06-08-175831_598x194_scrot](https://github.com/user-attachments/assets/84e16129-f93e-47d5-870e-a069bf95566a)

After:
![2025-06-08-175737_652x201_scrot](https://github.com/user-attachments/assets/c9cd77ec-c518-4ac2-a6d8-33030ae45481)