### PR TITLE
Add preliminary support for `web-mode`

### DIFF
--- a/base16-theme.el
+++ b/base16-theme.el
@@ -1028,6 +1028,12 @@ return the actual color value.  Otherwise return the value unchanged."
      (w3m-tab-unselected-unseen                    :foreground base03 :background base01)
      (w3m-tab-unselected-retrieving                :foreground base03 :background base01)
 
+;;;; web-mode
+     (web-mode-doctype-face                        :inherit font-lock-doc-face)
+     (web-mode-html-attr-name-face                 :inherit font-lock-variable-name-face)
+     (web-mode-html-tag-bracket-face               :inherit default)
+     (web-mode-html-tag-face                       :inherit font-lock-function-name-face)
+
 ;;;; which-func-mode
      (which-func                                   :foreground base0D :background unspecified :weight bold)
 


### PR DESCRIPTION
In addition to being useful on its own, `web-mode` is also used a basis for the TypeScript mode for `.tsx` files. It has opinionated faces, though, and those clash hard with some themes.
So far I haven't figured out where some of its more than 80 faces are used (most defer to the default font lock faces, but some don't), but I figured styling the most common ones might suffice for a good experience, like angle brackets, HTML tags, and HTML attributes.

### base16-greenscreen
Before:
![2025-06-08-213248_1125x691_scrot](https://github.com/user-attachments/assets/2932ac17-b17b-45bf-831d-211096f2a163)

After:
![2025-06-08-213319_1131x690_scrot](https://github.com/user-attachments/assets/f786c621-841f-40a9-afd1-2f522cee1ea2)
